### PR TITLE
feat: Modernize Python package development setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.create false
+
+    - name: Install dependencies
+      run: |
+        poetry install --no-root --no-interaction --no-ansi
+
+    - name: Lint with ruff
+      run: |
+        poetry run ruff .
+
+    - name: Format with black
+      run: |
+        poetry run black --check .
+
+    - name: Test with pytest
+      run: |
+        poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -229,6 +229,53 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "black"
+version = "23.12.1"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
+    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
+    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
+    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
+    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
+    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
+    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
+    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
+    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
+    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
+    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
+    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
+    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
+    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
+    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
+    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
+    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
+    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
+    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
+    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
+    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
+    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4) ; sys_platform != \"win32\" or implementation_name != \"pypy\"", "aiohttp (>=3.7.4,!=3.9.0) ; sys_platform == \"win32\" and implementation_name == \"pypy\""]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "blis"
 version = "0.7.11"
 description = "The Blis BLAS-like linear algebra library, as a self-contained C-extension."
@@ -449,7 +496,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
@@ -465,7 +512,7 @@ version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
@@ -507,7 +554,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "confection"
@@ -2596,6 +2643,23 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.4.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
+    {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -3441,6 +3505,33 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "ruff"
+version = "0.1.15"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.1.15-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5fe8d54df166ecc24106db7dd6a68d44852d14eb0729ea4672bb4d96c320b7df"},
+    {file = "ruff-0.1.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f0bfbb53c4b4de117ac4d6ddfd33aa5fc31beeaa21d23c45c6dd249faf9126f"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0d432aec35bfc0d800d4f70eba26e23a352386be3a6cf157083d18f6f5881c8"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9405fa9ac0e97f35aaddf185a1be194a589424b8713e3b97b762336ec79ff807"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c66ec24fe36841636e814b8f90f572a8c0cb0e54d8b5c2d0e300d28a0d7bffec"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6f8ad828f01e8dd32cc58bc28375150171d198491fc901f6f98d2a39ba8e3ff5"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86811954eec63e9ea162af0ffa9f8d09088bab51b7438e8b6488b9401863c25e"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd4025ac5e87d9b80e1f300207eb2fd099ff8200fa2320d7dc066a3f4622dc6b"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b17b93c02cdb6aeb696effecea1095ac93f3884a49a554a9afa76bb125c114c1"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ddb87643be40f034e97e97f5bc2ef7ce39de20e34608f3f829db727a93fb82c5"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:abf4822129ed3a5ce54383d5f0e964e7fef74a41e48eb1dfad404151efc130a2"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6c629cf64bacfd136c07c78ac10a54578ec9d1bd2a9d395efbee0935868bf852"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1bab866aafb53da39c2cadfb8e1c4550ac5340bb40300083eb8967ba25481447"},
+    {file = "ruff-0.1.15-py3-none-win32.whl", hash = "sha256:2417e1cb6e2068389b07e6fa74c306b2810fe3ee3476d5b8a96616633f40d14f"},
+    {file = "ruff-0.1.15-py3-none-win_amd64.whl", hash = "sha256:3837ac73d869efc4182d9036b1405ef4c73d9b1f88da2413875e34e0d6919587"},
+    {file = "ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360"},
+    {file = "ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e"},
+]
 
 [[package]]
 name = "setuptools"
@@ -4723,4 +4814,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "716522375257404cf4e0eeefca04f0416b71e07bafa7e3ea00cd83a7b0dad61d"
+content-hash = "7c191708c04e7a151473c9a4462d0f3434d43b0fa071b9c38cd36d3a242abd42"

--- a/pyner/__init__.py
+++ b/pyner/__init__.py
@@ -9,10 +9,9 @@ of predefined schemas for scientific and biomedical text.
 __version__ = "0.1.0"
 
 # Expose the primary user-facing function for easy access.
-from .data_handling.io import extract_entities
-
 # Expose the catalog features for schema customization and extension.
-from .catalog import get_schema, register_entity, PRESETS
+from .catalog import PRESETS, get_schema, register_entity
+from .data_handling.io import extract_entities
 
 __all__ = [
     "extract_entities",

--- a/pyner/catalog.py
+++ b/pyner/catalog.py
@@ -9,7 +9,7 @@ to dynamically generate Pydantic models for extraction.
 """
 
 import logging
-from typing import TypedDict, List, Dict, Optional, Type, Set
+from typing import Dict, List, Optional, Set, Type, TypedDict
 
 from pydantic import BaseModel, Field, create_model
 
@@ -27,6 +27,7 @@ class EntityDefinition(TypedDict):
                      including examples of what to extract and what to avoid.
         category: The logical category of the entity (e.g., "Disorders", "Chemicals").
     """
+
     name: str
     description: str
     category: str
@@ -75,7 +76,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract abnormal physiological processes or states at the cellular or organ level. This describes the 'how' of a disease. Examples: 'inflammation', 'necrosis', 'fibrosis', 'cellular atypia', 'insulin resistance'.",
         "category": "DISORDERS_AND_FINDINGS",
     },
-
     # Category: CHEMICALS_AND_DRUGS
     "ClinicalDrug": {
         "name": "Clinical Drug",
@@ -117,7 +117,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract the path by which a drug, fluid, poison, or other substance is taken into the body. Examples: 'oral', 'intravenous', 'subcutaneous', 'intramuscular', 'topical'.",
         "category": "CHEMICALS_AND_DRUGS",
     },
-
     # Category: PROCEDURES_AND_INTERVENTIONS
     "TherapeuticProcedure": {
         "name": "Therapeutic Procedure",
@@ -144,7 +143,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract instruments, apparatuses, or implants used for medical purposes. Examples: 'pacemaker', 'stent', 'ventilator', 'catheter', 'syringe'.",
         "category": "PROCEDURES_AND_INTERVENTIONS",
     },
-
     # Category: ANATOMY_AND_PHYSIOLOGY
     "AnatomicalStructure": {
         "name": "Anatomical Structure",
@@ -166,7 +164,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract normal functions and processes of living organisms or their parts. Examples: 'metabolism', 'respiration', 'digestion', 'synaptic transmission', 'glomerular filtration'.",
         "category": "ANATOMY_AND_PHYSIOLOGY",
     },
-
     # Category: GENETICS_AND_MOLECULAR
     "GeneOrGenome": {
         "name": "Gene or Genome",
@@ -193,7 +190,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract activities occurring at the molecular level, such as catalysis or binding. Examples: 'DNA binding', 'kinase activity', 'receptor antagonist', 'ion transport'.",
         "category": "GENETICS_AND_MOLECULAR",
     },
-
     # Category: EPIDEMIOLOGY_AND_POPULATION
     "PopulationGroup": {
         "name": "Population Group",
@@ -225,7 +221,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract disease-causing microorganisms. Examples: 'Staphylococcus aureus', 'Human Immunodeficiency Virus (HIV)', 'SARS-CoV-2', 'bacteria', 'virus'.",
         "category": "EPIDEMIOLOGY_AND_POPULATION",
     },
-
     # Category: STUDY_DESIGN_AND_METRICS
     "StudyDesign": {
         "name": "Study Design",
@@ -252,7 +247,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract terms for systematic errors in study design or conduct that can lead to incorrect results. Examples: 'selection bias', 'recall bias', 'confounding', 'publication bias'.",
         "category": "STUDY_DESIGN_AND_METRICS",
     },
-
     # Category: CLINICAL_TRIAL_SPECIFICS
     "TrialPhase": {
         "name": "Trial Phase",
@@ -299,7 +293,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract the number of participants enrolled in a study. Look for explicit mentions of the sample size. Examples: 'a total of 500 patients', 'N=250', 'sample of 100 individuals'.",
         "category": "CLINICAL_TRIAL_SPECIFICS",
     },
-
     # Category: ORGANIZATIONS_AND_CONTEXT
     "PharmaceuticalCompany": {
         "name": "Pharmaceutical Company",
@@ -331,7 +324,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract names of specific individuals, such as researchers, authors, or principal investigators. Examples: 'Dr. John Smith', 'the research team of Jane Doe'.",
         "category": "ORGANIZATIONS_AND_CONTEXT",
     },
-
     # Category: VETERINARY_MEDICINE
     "AnimalSpecies": {
         "name": "Animal Species",
@@ -353,7 +345,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract diagnostic, therapeutic, or surgical procedures performed on animals. Examples: 'spaying', 'dehorning', 'equine lameness examination', 'necropsy'.",
         "category": "VETERINARY_MEDICINE",
     },
-
     # Category: HEALTHCARE_ECONOMICS_AND_POLICY
     "HealthcareCost": {
         "name": "Healthcare Cost",
@@ -375,7 +366,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract names of health insurance companies or public payers. Examples: 'Blue Cross Blue Shield', 'UnitedHealthcare', 'Medicaid', 'NHS'.",
         "category": "HEALTHCARE_ECONOMICS_AND_POLICY",
     },
-
     # Category: PUBLIC_HEALTH_AND_SYSTEMS
     "PublicHealthIntervention": {
         "name": "Public Health Intervention",
@@ -397,7 +387,6 @@ ENTITY_REGISTRY: Dict[str, EntityDefinition] = {
         "description": "Extract mentions of differences in health outcomes between groups of people. Examples: 'health outcomes by income', 'racial health gap', 'disparities in access to care'.",
         "category": "PUBLIC_HEALTH_AND_SYSTEMS",
     },
-
     # Category: BIOINFORMATICS_AND_COMPUTATIONAL_BIOLOGY
     "SoftwareTool": {
         "name": "Software Tool",
@@ -529,7 +518,10 @@ PRESETS: Dict[str, List[str]] = {
 # == DYNAMIC FUNCTIONS
 # ==============================================================================
 
-def register_entity(key: str, definition: EntityDefinition, overwrite: bool = False) -> None:
+
+def register_entity(
+    key: str, definition: EntityDefinition, overwrite: bool = False
+) -> None:
     """
     Adds or updates an entity definition in the central registry at runtime.
 
@@ -552,9 +544,7 @@ def register_entity(key: str, definition: EntityDefinition, overwrite: bool = Fa
 
 
 def _generate_pydantic_model(
-    model_name: str,
-    description: str,
-    entity_keys: Set[str]
+    model_name: str, description: str, entity_keys: Set[str]
 ) -> Type[BaseModel]:
     """
     Dynamically creates a Pydantic BaseModel from a set of entity keys.
@@ -568,7 +558,7 @@ def _generate_pydantic_model(
         A new Pydantic BaseModel class with the specified fields.
     """
     fields = {}
-    for key in sorted(list(entity_keys)):  # Sort for consistent model definition
+    for key in sorted(entity_keys):  # Sort for consistent model definition
         if key in ENTITY_REGISTRY:
             entity_def = ENTITY_REGISTRY[key]
             # Use the key as the field name. Pydantic fields should be valid identifiers.
@@ -581,10 +571,14 @@ def _generate_pydantic_model(
                 Field(default_factory=list, description=entity_def["description"]),
             )
         else:
-            logger.warning(f"Entity key '{key}' not found in registry and will be skipped.")
+            logger.warning(
+                f"Entity key '{key}' not found in registry and will be skipped."
+            )
 
     if not fields:
-        raise ValueError("Cannot generate a Pydantic model with no fields. Check your entity keys.")
+        raise ValueError(
+            "Cannot generate a Pydantic model with no fields. Check your entity keys."
+        )
 
     # Use pydantic.create_model to dynamically construct the BaseModel
     dynamic_model = create_model(
@@ -601,7 +595,7 @@ def get_schema(
     include_entities: Optional[List[str]] = None,
     exclude_entities: Optional[List[str]] = None,
     schema_name: str = "CustomNERSchema",
-    schema_description: str = "A dynamically generated Pydantic model for scientific NER."
+    schema_description: str = "A dynamically generated Pydantic model for scientific NER.",
 ) -> Type[BaseModel]:
     """
     Retrieves a dynamically generated Pydantic schema based on specified criteria.
@@ -632,18 +626,25 @@ def get_schema(
     if preset:
         preset_upper = preset.upper()
         if preset_upper not in PRESETS:
-            raise ValueError(f"Preset '{preset}' not found. Available presets: {list(PRESETS.keys())}")
+            raise ValueError(
+                f"Preset '{preset}' not found. Available presets: {list(PRESETS.keys())}"
+            )
         selected_entity_keys.update(PRESETS[preset_upper])
-        logger.info(f"Loaded {len(PRESETS[preset_upper])} entities from preset: {preset}")
+        logger.info(
+            f"Loaded {len(PRESETS[preset_upper])} entities from preset: {preset}"
+        )
 
     # 2. Add entities from included categories
     if include_categories:
         cat_keys = {
-            key for key, definition in ENTITY_REGISTRY.items()
+            key
+            for key, definition in ENTITY_REGISTRY.items()
             if definition["category"] in include_categories
         }
         selected_entity_keys.update(cat_keys)
-        logger.info(f"Added {len(cat_keys)} entities from categories: {include_categories}")
+        logger.info(
+            f"Added {len(cat_keys)} entities from categories: {include_categories}"
+        )
 
     # 3. Add specific entities
     if include_entities:
@@ -652,7 +653,9 @@ def get_schema(
 
     # 4. If no selections were made, default to comprehensive
     if not selected_entity_keys:
-        logger.warning("No preset, categories, or entities specified. Defaulting to 'COMPREHENSIVE' preset.")
+        logger.warning(
+            "No preset, categories, or entities specified. Defaulting to 'COMPREHENSIVE' preset."
+        )
         selected_entity_keys.update(PRESETS["COMPREHENSIVE"])
 
     # 5. Remove any excluded entities
@@ -670,9 +673,11 @@ def get_schema(
         )
 
     # 7. Generate the Pydantic model
-    logger.info(f"Generating schema '{schema_name}' with {len(selected_entity_keys)} total fields.")
+    logger.info(
+        f"Generating schema '{schema_name}' with {len(selected_entity_keys)} total fields."
+    )
     return _generate_pydantic_model(
         model_name=schema_name,
         description=schema_description,
-        entity_keys=selected_entity_keys
+        entity_keys=selected_entity_keys,
     )

--- a/pyner/data_handling/chunking.py
+++ b/pyner/data_handling/chunking.py
@@ -49,7 +49,7 @@ def chunk_text_with_offsets(
             current_pos = pos + 1
         else:
             logger.warning(
-                f"Could not reliably find chunk in the original text. "
+                "Could not reliably find chunk in the original text. "
                 "This might occur with complex texts or normalization by the splitter. "
                 "The chunk will be skipped, which may affect the final output."
             )

--- a/pyner/models/config.py
+++ b/pyner/models/config.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,48 +10,50 @@ class ModelConfig(BaseModel):
     This schema standardizes common parameters and provides fields for provider-specific
     settings, ensuring a consistent interface for model creation.
     """
+
     provider: Literal["openai", "azure", "anthropic", "ollama"] = Field(
         default="openai",
-        description="The name of the LLM provider to use (e.g., 'openai', 'azure')."
+        description="The name of the LLM provider to use (e.g., 'openai', 'azure').",
     )
     model_name: str = Field(
         default="gpt-4o",
-        description="The specific model name to use, e.g., 'gpt-4o', 'claude-3-opus-20240229'."
+        description="The specific model name to use, e.g., 'gpt-4o', 'claude-3-opus-20240229'.",
     )
     temperature: float = Field(
         default=0.0,
         ge=0.0,
         le=2.0,
-        description="Controls randomness. Lower values make the model more deterministic."
+        description="Controls randomness. Lower values make the model more deterministic.",
     )
     max_tokens: Optional[int] = Field(
         default=None,
         gt=0,
-        description="The maximum number of tokens to generate in the completion."
+        description="The maximum number of tokens to generate in the completion.",
     )
     top_p: Optional[float] = Field(
         default=None,
         ge=0.0,
         le=1.0,
-        description="Controls diversity via nucleus sampling. 0.5 means half of all likelihood-weighted options are considered."
+        description="Controls diversity via nucleus sampling. 0.5 means half of all likelihood-weighted options are considered.",
     )
 
     # --- Azure Specific Fields ---
     azure_deployment: Optional[str] = Field(
         default=None,
-        description="The name of the Azure OpenAI deployment. Required if provider is 'azure'."
+        description="The name of the Azure OpenAI deployment. Required if provider is 'azure'.",
     )
     azure_endpoint: Optional[str] = Field(
         default=None,
-        description="The endpoint URL for the Azure OpenAI service. Required if provider is 'azure'."
+        description="The endpoint URL for the Azure OpenAI service. Required if provider is 'azure'.",
     )
     api_version: Optional[str] = Field(
         default=None,
         alias="azure_api_version",
-        description="The API version for the Azure OpenAI service. Defaults to the latest."
+        description="The API version for the Azure OpenAI service. Defaults to the latest.",
     )
 
     class Config:
         """Pydantic model configuration."""
+
         allow_population_by_field_name = True
         extra = "ignore"

--- a/pyner/models/factory.py
+++ b/pyner/models/factory.py
@@ -1,9 +1,10 @@
+from typing import Any, Dict
+
 from dotenv import load_dotenv
-from typing import Dict, Any
-from langchain_core.language_models import BaseLanguageModel
-from langchain_openai import ChatOpenAI, AzureChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_community.chat_models import ChatOllama
+from langchain_core.language_models import BaseLanguageModel
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from pyner.models.config import ModelConfig
 

--- a/pyner/observability/logging.py
+++ b/pyner/observability/logging.py
@@ -1,9 +1,11 @@
 import sys
+
 from loguru import logger
 
 # Configure the logger for the entire package
 # By setting it up here, any module that imports `logger` from this file
 # will get the same, pre-configured instance.
+
 
 def setup_logging(level="INFO", colorize=True):
     """
@@ -28,6 +30,7 @@ def setup_logging(level="INFO", colorize=True):
         ),
         colorize=colorize,
     )
+
 
 # Apply the default configuration when the module is imported.
 # This ensures logging is ready to use without explicit setup in other modules.

--- a/pyner/observability/visualization.py
+++ b/pyner/observability/visualization.py
@@ -1,11 +1,18 @@
 import hashlib
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 # A simple color palette for fallbacks, can be extended
 _COLOR_PALETTE = [
-    "#ff6961", "#ffb480", "#f8f38d", "#42d6a4",
-    "#08cad1", "#59adf6", "#9d94ff", "#c780e8"
+    "#ff6961",
+    "#ffb480",
+    "#f8f38d",
+    "#42d6a4",
+    "#08cad1",
+    "#59adf6",
+    "#9d94ff",
+    "#c780e8",
 ]
+
 
 def _get_color(text: str) -> str:
     """
@@ -43,12 +50,12 @@ def render_biores_html(tagged_tokens: List[Tuple[str, str]]) -> str:
     colors: Dict[str, str] = {}
 
     for token, tag in tagged_tokens:
-        if tag == 'O':
+        if tag == "O":
             html_spans += f"{token} "
             continue
 
         try:
-            _, entity_type = tag.split('-', 1)
+            _, entity_type = tag.split("-", 1)
         except ValueError:
             html_spans += f"{token} "
             continue
@@ -67,17 +74,13 @@ def render_biores_html(tagged_tokens: List[Tuple[str, str]]) -> str:
             "border-radius: 0.35em;"
         )
 
-        label_style = (
-            "font-size: 0.8em; "
-            "font-weight: bold; "
-            "margin-left: 0.4em;"
-        )
+        label_style = "font-size: 0.8em; " "font-weight: bold; " "margin-left: 0.4em;"
 
         html_spans += (
             f'<span style="{style}">'
-            f'{token}'
+            f"{token}"
             f'<span style="{label_style}">{entity_type}</span>'
-            f'</span> '
+            f"</span> "
         )
 
     return f"""
@@ -94,6 +97,7 @@ def render_biores_html(tagged_tokens: List[Tuple[str, str]]) -> str:
     </html>
     """
 
+
 def display_biores(tagged_tokens: List[Tuple[str, str]]):
     """
     Displays the rendered BIOSES HTML in environments like Jupyter notebooks.
@@ -105,7 +109,8 @@ def display_biores(tagged_tokens: List[Tuple[str, str]]):
         tagged_tokens: A list of (token, BIOSES tag) tuples.
     """
     try:
-        from IPython.display import display, HTML
+        from IPython.display import HTML, display
+
         # We only need the inner part of the HTML for display, not the full document
         html_content = render_biores_html(tagged_tokens)
         display(HTML(html_content))

--- a/pyner/prompting/prompt_manager.py
+++ b/pyner/prompting/prompt_manager.py
@@ -64,7 +64,12 @@ class ZeroShotStructured(BasePromptStrategy):
             "Present your findings as a JSON object."
         )
 
-        human_message = "Please extract all entities from the following text:\n\n" "```text\n" "{text_input}\n" "```"
+        human_message = (
+            "Please extract all entities from the following text:\n\n"
+            "```text\n"
+            "{text_input}\n"
+            "```"
+        )
 
         prompt = ChatPromptTemplate.from_messages(
             [

--- a/pyner/schemas/core_schemas.py
+++ b/pyner/schemas/core_schemas.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, Field
 from typing import List
+
+from pydantic import BaseModel, Field
+
 
 class BaseEntity(BaseModel):
     """
@@ -7,14 +9,16 @@ class BaseEntity(BaseModel):
 
     This is the intermediate format that the LLM is expected to produce.
     """
+
     type: str = Field(
         ...,
-        description="The category or type of the extracted entity (e.g., 'Disease', 'Symptom')."
+        description="The category or type of the extracted entity (e.g., 'Disease', 'Symptom').",
     )
     text: str = Field(
         ...,
-        description="The actual text span that was extracted from the source document."
+        description="The actual text span that was extracted from the source document.",
     )
+
 
 class Entities(BaseModel):
     """
@@ -22,7 +26,7 @@ class Entities(BaseModel):
 
     The LLM is expected to return a JSON object that conforms to this schema.
     """
+
     entities: List[BaseEntity] = Field(
-        ...,
-        description="A list of all entities extracted from the text."
+        ..., description="A list of all entities extracted from the text."
     )

--- a/pyner/utils/biores_converter.py
+++ b/pyner/utils/biores_converter.py
@@ -34,12 +34,12 @@ class BIOSESConverter:
             logger.info("No spaCy model provided. Loading 'en_core_web_sm' by default.")
             try:
                 self.nlp = spacy.load("en_core_web_sm")
-            except OSError:
+            except OSError as e:
                 logger.error(
                     "Could not load 'en_core_web_sm'. Please run the following command to install it:\n"
                     "python -m spacy download en_core_web_sm"
                 )
-                raise IOError("Default spaCy model not found.")
+                raise OSError("Default spaCy model not found.") from e
 
     def convert(self, text: str, entities: List[BaseEntity]) -> List[Tuple[str, str]]:
         """
@@ -107,7 +107,9 @@ class BIOSESConverter:
                         tags[span.end - 1] = f"E-{entity.type}"
 
             except re.error as e:
-                logger.warning(f"Could not compile regex for entity text: '{entity.text}'. Error: {e}")
+                logger.warning(
+                    f"Could not compile regex for entity text: '{entity.text}'. Error: {e}"
+                )
                 continue
 
         return list(zip([token.text for token in doc], tags))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,9 @@
 [tool.poetry]
-name = "pyNameEntityRecognition"
+name = "pyner"
 version = "0.1.0"
 description = "LLM-based Named Entity Recognition using LangChain and LangGraph"
 authors = ["Gowtham Rao <rao@ohdsi.org>"]
 license = "Apache-2.0"
-packages = [
-    { include = "pyner" }
-]
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -36,6 +33,8 @@ mypy = "^1.6.0"
 pytest-asyncio = "^0.21.0"
 pytest-cov = "^6.2.1"
 pytest-mock = "^3.14.1"
+black = "^23.11.0"
+ruff = "^0.1.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -44,3 +43,12 @@ build-backend = "poetry.core.masonry.api"
 [tool.mypy]
 python_version = "3.9"
 ignore_missing_imports = true
+
+[tool.black]
+line-length = 88
+target-version = ['py39']
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "W", "I", "UP", "B", "C4"]
+ignore = ["E501"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,20 @@
+from typing import Any, List, Type
+
 import pytest
-from pydantic import BaseModel, Field
-from typing import List, Type, Any
 from langchain_core.language_models.fake import FakeListLLM
-from langchain_core.runnables import Runnable
 from langchain_core.output_parsers import PydanticOutputParser
+from langchain_core.runnables import Runnable
+from pydantic import BaseModel, Field
+
 
 class TestSchema(BaseModel):
     """A Pydantic schema for use in tests."""
+
     Person: List[str] = Field(description="The name of a person.")
-    Location: List[str] = Field(description="A physical location, like a city or country.")
+    Location: List[str] = Field(
+        description="A physical location, like a city or country."
+    )
+
 
 class FakeStructuredLLM(FakeListLLM):
     """
@@ -16,7 +22,10 @@ class FakeStructuredLLM(FakeListLLM):
     It inherits from FakeListLLM to provide canned string responses and overrides
     the structured output method to parse that string into a Pydantic model.
     """
-    def with_structured_output(self, schema: Type[BaseModel], **kwargs: Any) -> Runnable:
+
+    def with_structured_output(
+        self, schema: Type[BaseModel], **kwargs: Any
+    ) -> Runnable:
         """
         Overrides the base method to return a chain that parses the fake response.
         """
@@ -24,10 +33,12 @@ class FakeStructuredLLM(FakeListLLM):
         # Return a new chain: the fake LLM's response -> parser
         return self | parser
 
+
 @pytest.fixture(scope="session")
 def test_schema() -> Type[BaseModel]:
     """Provides the TestSchema class."""
     return TestSchema
+
 
 @pytest.fixture
 def fake_llm_factory():
@@ -36,6 +47,8 @@ def fake_llm_factory():
     This allows tests to simulate specific LLM JSON outputs and test chains
     that rely on the with_structured_output method.
     """
+
     def _factory(responses: List[str]):
         return FakeStructuredLLM(responses=responses)
+
     return _factory

--- a/tests/data_handling/test_io.py
+++ b/tests/data_handling/test_io.py
@@ -1,33 +1,51 @@
-import pytest
+from unittest.mock import AsyncMock, patch
+
 import pandas as pd
+import pytest
 from datasets import Dataset
-from pydantic import BaseModel
-from unittest.mock import patch, MagicMock, AsyncMock
 
 from pyner.data_handling.io import (
-    biores_to_entities,
     _yield_texts,
+    biores_to_entities,
     extract_entities,
 )
 from pyner.schemas.core_schemas import BaseEntity, Entities
 
+
 class Person(BaseEntity):
     pass
+
 
 class Location(BaseEntity):
     pass
 
-@pytest.mark.parametrize("tagged_tokens, expected_entities", [
-    ([("John", "S-PERSON"), ("works", "O"), ("at", "O"), ("Google", "S-ORG")],
-     Entities(entities=[BaseEntity(type='PERSON', text='John'), BaseEntity(type='ORG', text='Google')])),
-    ([("New", "B-LOCATION"), ("York", "E-LOCATION")],
-     Entities(entities=[BaseEntity(type='LOCATION', text='New York')])),
-    ([("San", "B-LOCATION"), ("Francisco", "I-LOCATION"), ("Bay", "E-LOCATION")],
-     Entities(entities=[BaseEntity(type='LOCATION', text='San Francisco Bay')])),
-    ([], Entities(entities=[])),
-])
+
+@pytest.mark.parametrize(
+    "tagged_tokens, expected_entities",
+    [
+        (
+            [("John", "S-PERSON"), ("works", "O"), ("at", "O"), ("Google", "S-ORG")],
+            Entities(
+                entities=[
+                    BaseEntity(type="PERSON", text="John"),
+                    BaseEntity(type="ORG", text="Google"),
+                ]
+            ),
+        ),
+        (
+            [("New", "B-LOCATION"), ("York", "E-LOCATION")],
+            Entities(entities=[BaseEntity(type="LOCATION", text="New York")]),
+        ),
+        (
+            [("San", "B-LOCATION"), ("Francisco", "I-LOCATION"), ("Bay", "E-LOCATION")],
+            Entities(entities=[BaseEntity(type="LOCATION", text="San Francisco Bay")]),
+        ),
+        ([], Entities(entities=[])),
+    ],
+)
 def test_biores_to_entities(tagged_tokens, expected_entities):
     assert biores_to_entities(tagged_tokens) == expected_entities
+
 
 @pytest.mark.asyncio
 async def test_yield_texts():
@@ -53,16 +71,17 @@ async def test_yield_texts():
     with pytest.raises(ValueError):
         [x async for x in _yield_texts(df, None)]
 
+
 @pytest.mark.asyncio
-@patch('pyner.data_handling.io.CoreEngine')
-@patch('pyner.data_handling.io.ModelFactory')
+@patch("pyner.data_handling.io.CoreEngine")
+@patch("pyner.data_handling.io.ModelFactory")
 async def test_extract_entities(mock_factory, mock_engine):
     mock_engine_instance = mock_engine.return_value
     mock_engine_instance.run = AsyncMock(return_value=[("John", "S-PERSON")])
 
     # Test with string
     result = await extract_entities("John", Person, output_format="json")
-    assert result == {'entities': [{'type': 'PERSON', 'text': 'John'}]}
+    assert result == {"entities": [{"type": "PERSON", "text": "John"}]}
 
     # Test with list
     results = await extract_entities(["John", "Doe"], Person, output_format="conll")

--- a/tests/models/test_model_factory.py
+++ b/tests/models/test_model_factory.py
@@ -1,78 +1,78 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 from pydantic import ValidationError
 
 from pyner.models.config import ModelConfig
 from pyner.models.factory import ModelFactory
 
 
-@patch('pyner.models.factory.ChatOpenAI')
+@patch("pyner.models.factory.ChatOpenAI")
 def test_create_openai_model_with_extra_params(mock_chat_openai, mocker):
     """Tests creating a ChatOpenAI model with max_tokens and top_p."""
-    mocker.patch.dict('os.environ', {'OPENAI_API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"OPENAI_API_KEY": "test_key"})
     config = ModelConfig(
-        provider="openai",
-        model_name="gpt-4o",
-        max_tokens=100,
-        top_p=0.9
+        provider="openai", model_name="gpt-4o", max_tokens=100, top_p=0.9
     )
     ModelFactory.create(config)
     mock_chat_openai.assert_called_with(
-        model="gpt-4o",
-        temperature=0.0,
-        max_tokens=100,
-        model_kwargs={"top_p": 0.9}
+        model="gpt-4o", temperature=0.0, max_tokens=100, model_kwargs={"top_p": 0.9}
     )
 
-@patch('pyner.models.factory.ChatOpenAI')
+
+@patch("pyner.models.factory.ChatOpenAI")
 def test_create_openai_model(mock_chat_openai, mocker):
     """Tests the creation of a ChatOpenAI model."""
-    mocker.patch.dict('os.environ', {'OPENAI_API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"OPENAI_API_KEY": "test_key"})
     config = ModelConfig(provider="openai", model_name="gpt-4o")
     ModelFactory.create(config)
     mock_chat_openai.assert_called_once()
 
-@patch('pyner.models.factory.ChatAnthropic')
+
+@patch("pyner.models.factory.ChatAnthropic")
 def test_create_anthropic_model(mock_chat_anthropic, mocker):
     """Tests the creation of a ChatAnthropic model."""
-    mocker.patch.dict('os.environ', {'ANTHROPIC_API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
     config = ModelConfig(provider="anthropic", model_name="claude-3-opus")
     ModelFactory.create(config)
     mock_chat_anthropic.assert_called_once()
 
-@patch('pyner.models.factory.ChatOllama')
+
+@patch("pyner.models.factory.ChatOllama")
 def test_create_ollama_model(mock_chat_ollama):
     """Tests the creation of a ChatOllama model."""
     config = ModelConfig(provider="ollama", model_name="llama3")
     ModelFactory.create(config)
     mock_chat_ollama.assert_called_once()
 
-@patch('pyner.models.factory.AzureChatOpenAI')
+
+@patch("pyner.models.factory.AzureChatOpenAI")
 def test_create_azure_model(mock_azure_chat_openai, mocker):
     """Tests the creation of an AzureChatOpenAI model."""
-    mocker.patch.dict('os.environ', {
-        'AZURE_OPENAI_API_KEY': 'test_key',
-        'OPENAI_API_VERSION': '2023-05-15'
-    })
+    mocker.patch.dict(
+        "os.environ",
+        {"AZURE_OPENAI_API_KEY": "test_key", "OPENAI_API_VERSION": "2023-05-15"},
+    )
     config = ModelConfig(
         provider="azure",
         azure_deployment="my-deployment",
         azure_endpoint="https://my-endpoint.openai.azure.com/",
-        api_version="2023-05-15"
+        api_version="2023-05-15",
     )
     ModelFactory.create(config)
     mock_azure_chat_openai.assert_called_once()
 
-@patch('pyner.models.factory.AzureChatOpenAI')
+
+@patch("pyner.models.factory.AzureChatOpenAI")
 def test_create_azure_model_with_extra_params(mock_azure_chat_openai, mocker):
     """Tests creating an AzureChatOpenAI model with max_tokens and top_p."""
-    mocker.patch.dict('os.environ', {'AZURE_OPENAI_API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"AZURE_OPENAI_API_KEY": "test_key"})
     config = ModelConfig(
         provider="azure",
         azure_deployment="my-deployment",
         azure_endpoint="https://my-endpoint.openai.azure.com/",
         max_tokens=200,
-        top_p=0.8
+        top_p=0.8,
     )
     ModelFactory.create(config)
     mock_azure_chat_openai.assert_called_with(
@@ -80,59 +80,53 @@ def test_create_azure_model_with_extra_params(mock_azure_chat_openai, mocker):
         azure_endpoint="https://my-endpoint.openai.azure.com/",
         temperature=0.0,
         max_tokens=200,
-        model_kwargs={"top_p": 0.8}
+        model_kwargs={"top_p": 0.8},
     )
 
-@patch('pyner.models.factory.ChatAnthropic')
+
+@patch("pyner.models.factory.ChatAnthropic")
 def test_create_anthropic_model_with_extra_params(mock_chat_anthropic, mocker):
     """Tests creating a ChatAnthropic model with max_tokens and top_p."""
-    mocker.patch.dict('os.environ', {'ANTHROPIC_API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"})
     config = ModelConfig(
-        provider="anthropic",
-        model_name="claude-3-opus",
-        max_tokens=150,
-        top_p=0.85
+        provider="anthropic", model_name="claude-3-opus", max_tokens=150, top_p=0.85
     )
     ModelFactory.create(config)
     mock_chat_anthropic.assert_called_with(
-        model="claude-3-opus",
-        temperature=0.0,
-        max_tokens=150,
-        top_p=0.85
+        model="claude-3-opus", temperature=0.0, max_tokens=150, top_p=0.85
     )
 
-@patch('pyner.models.factory.ChatOllama')
+
+@patch("pyner.models.factory.ChatOllama")
 def test_create_ollama_model_with_extra_params(mock_chat_ollama):
     """Tests creating a ChatOllama model with top_p."""
-    config = ModelConfig(
-        provider="ollama",
-        model_name="llama3",
-        top_p=0.95
-    )
+    config = ModelConfig(provider="ollama", model_name="llama3", top_p=0.95)
     ModelFactory.create(config)
-    mock_chat_ollama.assert_called_with(
-        model="llama3",
-        temperature=0.0,
-        top_p=0.95
-    )
+    mock_chat_ollama.assert_called_with(model="llama3", temperature=0.0, top_p=0.95)
+
 
 def test_create_azure_model_missing_deployment_raises_error():
     """Tests that missing azure_deployment for Azure raises ValueError."""
     config = ModelConfig(
-        provider="azure",
-        azure_endpoint="https://my-endpoint.openai.azure.com/"
+        provider="azure", azure_endpoint="https://my-endpoint.openai.azure.com/"
     )
-    with pytest.raises(ValueError, match="'azure_deployment' and 'azure_endpoint' must be specified"):
+    with pytest.raises(
+        ValueError, match="'azure_deployment' and 'azure_endpoint' must be specified"
+    ):
         ModelFactory.create(config)
+
 
 def test_unsupported_provider_config_raises_error():
     """Tests that an unsupported provider raises a ValidationError on ModelConfig."""
     with pytest.raises(ValidationError):
         ModelConfig(provider="unsupported_provider")
 
+
 def test_factory_unsupported_provider_raises_error(mocker):
     """Tests that the factory raises a ValueError for an unsupported provider."""
     config = ModelConfig()
-    mocker.patch.object(config, 'provider', 'unsupported_provider')
-    with pytest.raises(ValueError, match="Unsupported model provider: 'unsupported_provider'"):
+    mocker.patch.object(config, "provider", "unsupported_provider")
+    with pytest.raises(
+        ValueError, match="Unsupported model provider: 'unsupported_provider'"
+    ):
         ModelFactory.create(config)

--- a/tests/observability/test_visualization.py
+++ b/tests/observability/test_visualization.py
@@ -1,10 +1,11 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from pyner.observability.visualization import (
     _get_color,
-    render_biores_html,
     display_biores,
+    render_biores_html,
 )
+
 
 def test_get_color():
     """Tests that _get_color returns a valid and consistent color."""
@@ -17,9 +18,15 @@ def test_get_color():
     assert color1.startswith("#")
     assert len(color1) == 7
 
+
 def test_render_biores_html_simple():
     """Tests basic HTML rendering for BIOS-tagged tokens."""
-    tagged_tokens = [("John", "S-PERSON"), ("works", "O"), ("at", "O"), ("Google", "S-ORG")]
+    tagged_tokens = [
+        ("John", "S-PERSON"),
+        ("works", "O"),
+        ("at", "O"),
+        ("Google", "S-ORG"),
+    ]
     html = render_biores_html(tagged_tokens)
 
     assert "John" in html
@@ -29,10 +36,12 @@ def test_render_biores_html_simple():
     assert "ORG" in html
     assert 'style="background-color:' in html
 
+
 def test_render_biores_html_empty():
     """Tests rendering with no tokens."""
     html = render_biores_html([])
     assert "<body></body>" in html.replace(" ", "")
+
 
 def test_render_biores_html_malformed_tag():
     """Tests that a malformed tag is handled gracefully."""
@@ -41,14 +50,18 @@ def test_render_biores_html_malformed_tag():
     assert "MALFORMED" not in html
     assert "test" in html
 
+
 def test_display_biores_with_ipython():
     """Tests that display_biores calls IPython's display and HTML."""
     mock_display = MagicMock()
     mock_html = MagicMock()
-    with patch.dict('sys.modules', {
-        'IPython': MagicMock(),
-        'IPython.display': MagicMock(display=mock_display, HTML=mock_html)
-    }):
+    with patch.dict(
+        "sys.modules",
+        {
+            "IPython": MagicMock(),
+            "IPython.display": MagicMock(display=mock_display, HTML=mock_html),
+        },
+    ):
         tagged_tokens = [("test", "S-ENTITY")]
         display_biores(tagged_tokens)
         mock_html.assert_called_once()
@@ -57,7 +70,7 @@ def test_display_biores_with_ipython():
 
 def test_display_biores_without_ipython(capsys):
     """Tests the fallback behavior when IPython is not installed."""
-    with patch.dict('sys.modules', {'IPython': None}):
+    with patch.dict("sys.modules", {"IPython": None}):
         tagged_tokens = [("test", "S-ENTITY")]
         display_biores(tagged_tokens)
         captured = capsys.readouterr()

--- a/tests/prompting/test_prompt_manager.py
+++ b/tests/prompting/test_prompt_manager.py
@@ -1,17 +1,23 @@
+from typing import List
+
 import pytest
 from pydantic import BaseModel, Field
-from typing import List
+
 from pyner.prompting.prompt_manager import PromptManager, ZeroShotStructured
+
 
 class SampleSchema(BaseModel):
     """A sample schema for testing."""
+
     person: List[str] = Field(description="The name of a person.")
     location: List[str] = Field(description="A physical location.")
+
 
 @pytest.fixture
 def prompt_manager():
     """Provides a PromptManager with the zero-shot strategy."""
     return PromptManager(strategy=ZeroShotStructured())
+
 
 def test_zero_shot_prompt_generation(prompt_manager):
     template = prompt_manager.get_prompt_template(schema=SampleSchema)
@@ -21,7 +27,9 @@ def test_zero_shot_prompt_generation(prompt_manager):
 
     # Check that the system message contains the schema descriptions
     system_message = template.messages[0].prompt.template
-    assert "You must extract entities that match the following schema:" in system_message
+    assert (
+        "You must extract entities that match the following schema:" in system_message
+    )
     assert "Person" in system_message
     assert "The name of a person." in system_message
     assert "Location" in system_message

--- a/tests/utils/test_biores_converter.py
+++ b/tests/utils/test_biores_converter.py
@@ -1,11 +1,14 @@
 import pytest
+
 from pyner.schemas.core_schemas import BaseEntity
 from pyner.utils.biores_converter import BIOSESConverter
+
 
 @pytest.fixture(scope="module")
 def converter():
     """Provides a BIOSESConverter instance for the tests."""
     return BIOSESConverter()
+
 
 def test_biores_converter_simple_case(converter):
     text = "Apple Inc. is a technology company."
@@ -16,8 +19,8 @@ def test_biores_converter_simple_case(converter):
     assert ("Apple", "B-ORG") in result
     assert ("Inc.", "E-ORG") in result
     # Find the token for 'is' and check it's 'O'
-    is_tag = [tag for token, tag in result if token == 'is']
-    assert is_tag == ['O']
+    is_tag = [tag for token, tag in result if token == "is"]
+    assert is_tag == ["O"]
 
 
 def test_biores_converter_single_token_entity(converter):
@@ -27,6 +30,7 @@ def test_biores_converter_single_token_entity(converter):
 
     assert ("Google", "S-ORG") in result
     assert ("like", "O") in result
+
 
 def test_biores_converter_multiple_entities(converter):
     text = "Apple and Google are rivals."
@@ -39,6 +43,7 @@ def test_biores_converter_multiple_entities(converter):
     assert ("Apple", "S-ORG") in result
     assert ("Google", "S-ORG") in result
     assert ("rivals", "O") in result
+
 
 def test_biores_converter_nested_entities(converter):
     """Tests that longer entities are prioritized over shorter, nested ones."""
@@ -55,6 +60,7 @@ def test_biores_converter_nested_entities(converter):
     # Ensure the shorter entity "New York" was not tagged as GPE
     assert not any(tag.endswith("-GPE") for _, tag in result)
 
+
 def test_biores_converter_no_entities(converter):
     text = "Just a simple sentence."
     entities = []
@@ -62,6 +68,7 @@ def test_biores_converter_no_entities(converter):
 
     for _, tag in result:
         assert tag == "O"
+
 
 def test_biores_converter_misaligned_span(converter):
     """Tests that spans not aligning with token boundaries are skipped."""
@@ -72,6 +79,7 @@ def test_biores_converter_misaligned_span(converter):
 
     for _, tag in result:
         assert tag == "O"
+
 
 def test_biores_converter_three_token_entity(converter):
     text = "I love New York City."


### PR DESCRIPTION
Rename package to 'pyner' in pyproject.toml for PEP 8 compliance.

Add Black for code formatting and Ruff for linting. Configure them in pyproject.toml and apply them to the entire codebase to enforce a consistent style and catch potential errors.

Add a GitHub Actions CI workflow to automate checks for formatting, linting, and tests on push and pull requests. The workflow runs against Python versions 3.9, 3.10, and 3.11.