### PR TITLE
Fix CI by downloading spacy model (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       run: |
         poetry run black --check .
 
+    - name: Download spacy model
+      run: |
+        poetry run python -m spacy download en_core_web_sm
+
     - name: Test with pytest
       run: |
         poetry run pytest


### PR DESCRIPTION
The tests were failing in the CI environment because the `en_core_web_sm` spacy model was not downloaded. This change adds a step to the CI workflow to download the model before running the tests.